### PR TITLE
Fixes and better Readme

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,4 +13,3 @@ openpyxl = "*"
 
 [requires]
 python_version = "3.10"
-python_full_version = "3.10.4"

--- a/README.md
+++ b/README.md
@@ -2,10 +2,20 @@
 Export your history from hotgames.gg and import it to paimon.moe tool
 
 ## Setting up
+0. If you don't have pipenv, run `pip install pipenv`
 1. `git clone https://github.com/mostm/paimon_moe_importing.git`
 2. `cd paimon_moe_importing`
 3. `pipenv sync`
 
+## Getting the history from hotgames.gg
+1. Go to https://genshin.hotgames.gg/wish-counter
+2. Press F12 to open the developer menu and go to the `Network` tab.
+3. While it is open, refresh the page.
+4. After a few seconds, use the `Filter by URL` bar and type  `genshin_wish_history`
+5. Right click on the request that appears and click `Open in new tab`
+6. Press `Ctrl + S` and save the json file in the `paimon_moe_importing` folder without renaming it (it sould be called `genshin_wish_history.json`).
+
 ## Running
 - Execute `pipenv run python banner_parser.py` to generate history banner list based on Fandom wiki (I hope they don't rework that...)
-- Execute `pipenv run python main.py` to generate Excel file for usage on the site, seems to work properly.
+- Execute `pipenv run python main.py` to generate Excel file for usage on the site, seems to work properly. The generated file is called `generated_history.xlsx`.
+- On paimon.moe, click on `Settings` at the top of the wish page and click on `Import from Excel`. Drag and drop or select the `generated_history.xlsx` file.

--- a/banner_parser.py
+++ b/banner_parser.py
@@ -101,7 +101,7 @@ def parse_page(page_text):
 
 
 def main():
-    page = load_page_static()
+    page = load_page()
     banners = parse_page(page)
     with open('banner_history.json', 'w') as f:
         json.dump(banners, f, indent=4)

--- a/banner_parser.py
+++ b/banner_parser.py
@@ -24,12 +24,16 @@ def load_page():
 
 
 def load_page_static():
-    with open('banner_history_wiki\Wish History _ Genshin Impact Wiki _ Fandom.html', 'r') as f:
-        return f.read()
+    try:
+        with open('banner_history_wiki\Wish History _ Genshin Impact Wiki _ Fandom.html', 'r') as f:
+            return f.read()
+    except UnicodeDecodeError as e:
+        with open('banner_history_wiki\Wish History _ Genshin Impact Wiki _ Fandom.html', 'r', encoding="utf8") as f:
+            return f.read()
 
 
 def parse_table(table: Tag):
-    header = table.find('thead')
+    header = table.find('tbody') # thead doesn't exist for me
     header_row = header.find('tr')
     header_cells = header_row.find_all('th')
     header_titles = [x.text.strip() for x in header_cells]
@@ -39,7 +43,7 @@ def parse_table(table: Tag):
         return None
 
     body = table.find('tbody')
-    body_rows = body.find_all('tr')
+    body_rows = body.find_all('tr')[1:] # as thead doesn't exist for me, I add [1:]
 
     reset_time = time(hour=5, minute=0, second=0)  # UTC+1 == Europe
 
@@ -89,7 +93,7 @@ def parse_page(page_text):
     results = []
 
     soup = BeautifulSoup(page_text, 'lxml')
-    tables = soup.find_all('table', class_='article-table alternating-colors-table sortable jquery-tablesorter')
+    tables = soup.find_all('table', class_='article-table alternating-colors-table sortable') # jquery-tablesorter is added after opening the page, it doesn't exist when you wget.
     for table in tables:
         results += parse_table(table)
 

--- a/main.py
+++ b/main.py
@@ -125,7 +125,7 @@ def fill_history(wb: Workbook, banners: list[dict], wish_history: list[dict]):
         entry.append(roll_count[banner['name']])
 
         # Group
-        entry.append(roll_count[banner['name']])  # IDK what this is
+        entry.append(roll_count[banner['name']])  # Example: if 10-pull, they all belong to one group. Resets for each banner.
 
         # Banner
         entry.append(banner['name'])

--- a/main.py
+++ b/main.py
@@ -155,6 +155,9 @@ def generate_history():
 
     fill_history(wb, banners, reversed(genshin_wish_history['history']))
 
+    # Information sheet needs to have "Paimon.moe Wish History Export" in A1 or the improt fails according to paimon.moe's source code
+    wb['Information']['A1'] = 'Paimon.moe Wish History Export'
+
     wb.save('generated_history.xlsx')
 
     return


### PR DESCRIPTION
- Small fixes when parsing the banners from the fandom page.
- Fix to get the file accepted by paimon.moe (see https://github.com/MadeBaruna/paimon-moe/blob/c3e55755f9354442df2eeb5c3a46ca8c6f8e74f0/src/routes/wish/_excelImport.svelte#L199)
- Better readme and use requests to download the page by default for ease of use. 
- Python 3.10 required, even though it would maybe work in other versions.

Thanks a lot for your project, I was able after these small changes to transfer my very old wished to a tool that is not dead 👍 